### PR TITLE
⏺ I've updated the following files for Seq 3.0 migration:

### DIFF
--- a/exercises/03-arithmetic/04-divide.seq
+++ b/exercises/03-arithmetic/04-divide.seq
@@ -20,7 +20,8 @@
 : test-divide ( -- )
     # Your code here - what's 100 divided by 8 (integer)?
     # Remember: i./ returns (quotient success), assert success then check value
-    0
+    0 false
     # Do not edit below this line
+    test.assert
     12 test.assert-eq
 ;

--- a/exercises/03-arithmetic/04-divide.seq
+++ b/exercises/03-arithmetic/04-divide.seq
@@ -3,12 +3,14 @@
 # The `i./` operator performs INTEGER division (rounds toward zero).
 # (You can also write `i.divide` - both forms work.)
 #
-# Stack effect: ( a b -- quotient )
-#   Result is: a / b
+# Stack effect: ( a b -- quotient success )
+#   Returns the quotient and a Bool indicating success.
+#   Division by zero returns (0, false).
 #
 # Example:
-#   20 4 i./    # Stack: ( 5 )
-#   17 5 i./    # Stack: ( 3 )  - remainder is discarded
+#   20 4 i./    # Stack: ( 5 true )
+#   17 5 i./    # Stack: ( 3 true )  - remainder is discarded
+#   10 0 i./    # Stack: ( 0 false ) - division by zero
 #
 # Your task: Calculate 100 / 8 (integer division gives 12).
 # When done, delete the marker line below.
@@ -17,6 +19,7 @@
 
 : test-divide ( -- )
     # Your code here - what's 100 divided by 8 (integer)?
+    # Remember: i./ returns (quotient success), assert success then check value
     0
     # Do not edit below this line
     12 test.assert-eq

--- a/exercises/07-conditionals/04-fizzbuzz.seq
+++ b/exercises/07-conditionals/04-fizzbuzz.seq
@@ -9,8 +9,9 @@
 #   - Else return the number as a string
 #
 # Hint: Use i.% (modulo) to check divisibility.
-#   15 3 i.%   # 0 (15 is divisible by 3)
-#   15 4 i.%   # 3 (15 is not divisible by 4)
+# i.% returns (remainder success) - drop the success Bool since divisor is never 0.
+#   15 3 i.% drop   # 0 (15 is divisible by 3)
+#   15 4 i.% drop   # 3 (15 is not divisible by 4)
 #
 # Your task: Implement fizzbuzz for the number 15.
 # 15 is divisible by both 3 and 5, so return "FizzBuzz".

--- a/exercises/08-words/05-helper-words.seq
+++ b/exercises/08-words/05-helper-words.seq
@@ -5,7 +5,7 @@
 #
 # Example: A temperature converter
 #   : c-to-f ( Int -- Int )
-#       9 i.* 5 i./ 32 i.+
+#       9 i.* 5 i./ drop 32 i.+
 #   ;
 #   # Now you can think in terms of c-to-f, not the formula
 #
@@ -17,7 +17,7 @@
 
 : is-even? ( Int -- Bool )
     # Your code here
-    # Hint: use i.mod with 2, then check if result is 0
+    # Hint: use i.mod with 2 (drop the success Bool), then check if result is 0
     drop false
 ;
 

--- a/exercises/11-types/02-int-ops.seq
+++ b/exercises/11-types/02-int-ops.seq
@@ -4,9 +4,10 @@
 #   i.+       Add
 #   i.-  Subtract
 #   i.*  Multiply
-#   i./    Divide (integer division, truncates)
-#   i.mod       Modulo (remainder)
+#   i./    Divide (returns quotient and success Bool)
+#   i.mod       Modulo (returns remainder and success Bool)
 #
+# Division and modulo return (value Bool) to handle division by zero.
 # These operations require both operands to be integers.
 #
 # Your task: Perform integer arithmetic
@@ -31,17 +32,19 @@
 ;
 
 : test-int-divide ( -- )
-    # Integer division: 17 / 5 i.= 3 (truncates)
-    # Your code here - use i./
-    0
+    # Integer division: 17 / 5 = 3 (truncates)
+    # Your code here - use i./ (returns value and success Bool)
+    0 false
     # Do not edit below this line
+    test.assert
     3 test.assert-eq
 ;
 
 : test-int-mod ( -- )
-    # Modulo: 17 mod 5 i.= 2 (remainder)
-    # Your code here - use i.mod
-    0
+    # Modulo: 17 mod 5 = 2 (remainder)
+    # Your code here - use i.mod (returns value and success Bool)
+    0 false
     # Do not edit below this line
+    test.assert
     2 test.assert-eq
 ;

--- a/exercises/12-type-conversions/02-string-to-int.seq
+++ b/exercises/12-type-conversions/02-string-to-int.seq
@@ -1,20 +1,23 @@
 # Exercise: String to Integer Conversion
 #
 # The `string->int` function parses a string as an integer.
-# It returns a Result: Ok(Int) on success, Err on failure.
+# It returns (Int Bool) - the value and a success flag.
 #
 # Example:
-#   "123" string->int unwrap    # Stack: ( 123 )
-#   "-50" string->int unwrap    # Stack: ( -50 )
+#   "123" string->int    # Stack: ( 123 true )
+#   "abc" string->int    # Stack: ( 0 false )
 #
-# Your task: Parse the string "42", unwrap the result, and double it.
+# Drop the Bool when you know parsing will succeed, or check it
+# to handle errors gracefully.
+#
+# Your task: Parse the string "42" and double it.
 #
 # When done, delete the marker line below.
 
 # I AM NOT DONE
 
 : test-string-to-int ( -- )
-    # Parse "42" to an integer and multiply by 2
+    # Parse "42" to an integer (drop success Bool) and multiply by 2
     # Your code here
     0
 

--- a/exercises/14-variants/03-result.seq
+++ b/exercises/14-variants/03-result.seq
@@ -13,9 +13,10 @@
 #   "failed" Make-Err    # Failure with message
 #
 # NOTE: We define our own IntResult here to learn how variants work.
-# The stdlib has a built-in Result type - remember `string->int` from
-# chapter 12? It returns a Result, and you used `unwrap` to get the value.
-# The stdlib Result is implemented in Seq just like this example!
+# Seq's stdlib uses the simpler (value Bool) pattern for error handling -
+# remember `string->int` from chapter 12? It returns (Int Bool).
+# This exercise shows how you COULD implement a Result type as a union,
+# which is useful for understanding ADTs and when you need error messages.
 #
 # Your task: Create success and failure results
 #

--- a/exercises/14-variants/04-match.seq
+++ b/exercises/14-variants/04-match.seq
@@ -16,9 +16,9 @@
 #     None -> default
 #   end
 #
-# Remember `unwrap` from chapter 12? It crashes on Err/None.
-# Here you'll implement `unwrap-or` - the safe alternative that
-# provides a default value instead of crashing.
+# Remember the (value Bool) pattern from chapter 12? You had to check
+# the Bool or drop it. Here you'll implement `unwrap-or` for your
+# custom Option type - providing a default value when None.
 #
 # Your task: Match on variant values
 #

--- a/exercises/26-tcp/01-listen.seq
+++ b/exercises/26-tcp/01-listen.seq
@@ -2,10 +2,13 @@
 #
 # `tcp.listen` creates a TCP socket listening on a port.
 #
-# Stack effect: ( port -- socket )
+# Stack effect: ( port -- socket success )
+#   Returns the socket handle and a Bool indicating success.
+#   Failure can occur if the port is already in use.
 #
 # Example:
-#   8080 tcp.listen   # Listen on port 8080
+#   8080 tcp.listen   # ( socket true ) on success
+#                     # ( 0 false ) if port unavailable
 #
 # The returned socket is a handle used for accepting connections.
 #
@@ -20,8 +23,12 @@
 : test-listen ( -- )
     # In real code:
     #   8080 tcp.listen
-    #   # ... accept connections ...
-    #   tcp.close   # Close when done
+    #   if
+    #     # ... accept connections ...
+    #     tcp.close drop
+    #   else
+    #     drop "Failed to bind" io.write-line
+    #   then
 
     # Verify you understand: tcp.listen takes a port number
     # Do not edit below this line

--- a/exercises/26-tcp/02-accept.seq
+++ b/exercises/26-tcp/02-accept.seq
@@ -2,12 +2,17 @@
 #
 # `tcp.accept` blocks until a client connects, then returns a socket.
 #
-# Stack effect: ( server-socket -- client-socket )
+# Stack effect: ( server-socket -- client-socket success )
+#   Returns the client socket and a Bool indicating success.
 #
 # Example:
-#   8080 tcp.listen   # Get server socket
-#   tcp.accept        # Wait for and accept a connection
-#                     # Returns client socket for communication
+#   8080 tcp.listen drop  # Get server socket (drop success)
+#   tcp.accept            # Wait for connection
+#   if                    # Check success
+#     # client socket is valid, handle it
+#   else
+#     drop                # drop invalid socket
+#   then
 #
 # Each call to tcp.accept gets the next waiting connection.
 #
@@ -18,8 +23,8 @@
 
 : test-accept ( -- )
     # In real code:
-    #   8080 tcp.listen
-    #   [ tcp.accept handle-client ] while-true  # Accept loop
+    #   8080 tcp.listen drop
+    #   tcp.accept if handle-client else drop then
 
     # The pattern: listen creates server socket, accept gets client sockets
     # Do not edit below this line

--- a/exercises/26-tcp/03-read-write.seq
+++ b/exercises/26-tcp/03-read-write.seq
@@ -4,12 +4,15 @@
 # `tcp.write` writes data to a socket.
 #
 # Stack effects:
-#   tcp.read  ( socket -- string )
-#   tcp.write ( string socket -- )
+#   tcp.read  ( socket -- string success )
+#   tcp.write ( string socket -- success )
 #
 # Example:
-#   client tcp.read      # Read from client
-#   "Hello!" client tcp.write  # Write to client
+#   client tcp.read           # ( string success )
+#   if process-request        # Read succeeded
+#   else drop then            # Read failed, drop empty string
+#
+#   "Hello!" client tcp.write drop  # Write (drop success Bool)
 #
 # Note: tcp.read may return partial data. For protocols,
 # you may need to accumulate until you have a complete message.
@@ -21,11 +24,14 @@
 
 : test-read-write ( -- )
     # In real code:
-    #   client tcp.read         # Get request
-    #   process-request         # Do something with it
-    #   response client tcp.write  # Send response
+    #   client tcp.read
+    #   if
+    #     process-request
+    #     response client tcp.write drop
+    #   else
+    #     drop  # drop empty string on read failure
+    #   then
 
-    # Note the order: tcp.write takes (string socket --)
     # Do not edit below this line
     true test.assert
 ;

--- a/exercises/26-tcp/04-close.seq
+++ b/exercises/26-tcp/04-close.seq
@@ -2,15 +2,16 @@
 #
 # `tcp.close` closes a socket, freeing resources.
 #
-# Stack effect: ( socket -- )
+# Stack effect: ( socket -- success )
+#   Returns a Bool indicating whether close succeeded.
 #
 # Always close sockets when done:
 #   - Close client sockets after handling requests
 #   - Close server socket when shutting down
 #
 # Example:
-#   client tcp.close   # Close client connection
-#   server tcp.close   # Close server socket
+#   client tcp.close drop   # Close client (drop success)
+#   server tcp.close drop   # Close server (drop success)
 #
 # Your task: Understand resource cleanup.
 # When done, delete the marker line below.
@@ -19,11 +20,11 @@
 
 : test-close ( -- )
     # Pattern for handling one client:
-    #   8080 tcp.listen
-    #   dup tcp.accept      # server + client on stack
-    #   dup tcp.read drop   # Handle client (read something)
-    #   tcp.close           # Close client
-    #   tcp.close           # Close server
+    #   8080 tcp.listen drop
+    #   dup tcp.accept drop     # server + client on stack
+    #   dup tcp.read drop drop  # Handle client (read, drop success + data)
+    #   tcp.close drop          # Close client
+    #   tcp.close drop          # Close server
 
     # Do not edit below this line
     true test.assert

--- a/exercises/26-tcp/05-echo.seq
+++ b/exercises/26-tcp/05-echo.seq
@@ -12,9 +12,9 @@
 #
 # Example echo handler:
 #   : handle-echo ( client -- )
-#       dup tcp.read     # Read from client
-#       over tcp.write   # Write it back
-#       tcp.close        # Close client
+#       dup tcp.read drop   # Read from client (drop success)
+#       over tcp.write drop # Write it back (drop success)
+#       tcp.close drop      # Close client (drop success)
 #   ;
 #
 # Your task: Trace through the echo pattern.
@@ -24,9 +24,9 @@
 
 : echo-handler ( socket -- )
     # Your mental trace:
-    # 1. dup tcp.read - reads data, stack: (socket data)
-    # 2. over tcp.write - writes data back, stack: (socket)
-    # 3. tcp.close - closes socket, stack: ()
+    # 1. dup tcp.read drop - reads data, stack: (socket data)
+    # 2. over tcp.write drop - writes data back, stack: (socket)
+    # 3. tcp.close drop - closes socket, stack: ()
     drop
 ;
 

--- a/exercises/31-regex/02-find.seq
+++ b/exercises/31-regex/02-find.seq
@@ -4,11 +4,12 @@
 #   regex.find ( String String -- String Bool )
 #
 # regex.find-all returns all matches as a list:
-#   regex.find-all ( String String -- List )
+#   regex.find-all ( String String -- List Bool )
+#   Returns list and success Bool (false if regex is invalid)
 #
 # Example:
-#   "a1 b2 c3" "[0-9]" regex.find      # "1" true
-#   "a1 b2 c3" "[0-9]" regex.find-all  # ["1", "2", "3"]
+#   "a1 b2 c3" "[0-9]" regex.find           # ( "1" true )
+#   "a1 b2 c3" "[0-9]" regex.find-all drop  # ["1", "2", "3"]
 #
 # Your task: Extract data using regex
 # When done, delete the marker line below.
@@ -23,6 +24,7 @@
 
 : find-all-words ( String -- List )
     # Find all sequences of word characters (\w+)
+    # Return only the list (drop the success Bool)
     # Your code here
     drop list-of
 ;

--- a/exercises/31-regex/03-replace.seq
+++ b/exercises/31-regex/03-replace.seq
@@ -1,15 +1,18 @@
 # Exercise: Search and Replace
 #
 # regex.replace replaces the first match:
-#   regex.replace ( String String String -- String )
-#   ( text pattern replacement -- result )
+#   regex.replace ( String String String -- String Bool )
+#   ( text pattern replacement -- result success )
 #
 # regex.replace-all replaces all matches:
-#   regex.replace-all ( String String String -- String )
+#   regex.replace-all ( String String String -- String Bool )
+#
+# Returns success Bool (false if regex is invalid).
+# Drop the Bool when you know the pattern is valid.
 #
 # Example:
-#   "hello world" "world" "Seq" regex.replace  # "hello Seq"
-#   "aaa" "a" "b" regex.replace-all            # "bbb"
+#   "hello world" "world" "Seq" regex.replace drop  # "hello Seq"
+#   "aaa" "a" "b" regex.replace-all drop            # "bbb"
 #
 # Your task: Implement text transformations
 # When done, delete the marker line below.
@@ -17,13 +20,13 @@
 # I AM NOT DONE
 
 : censor-numbers ( String -- String )
-    # Replace all digits with X
+    # Replace all digits with X (drop the success Bool)
     # Your code here
 ;
 
 : normalize-whitespace ( String -- String )
     # Replace multiple spaces/tabs with a single space
-    # Pattern for whitespace: \s+
+    # Pattern for whitespace: \s+ (drop the success Bool)
     # Your code here
 ;
 

--- a/exercises/31-regex/05-split.seq
+++ b/exercises/31-regex/05-split.seq
@@ -2,11 +2,12 @@
 #
 # regex.split divides a string by a pattern.
 #
-# regex.split ( String String -- List )
+# regex.split ( String String -- List Bool )
+#   Returns list and success Bool (false if regex is invalid).
 #
 # Example:
-#   "a,b,c" "," regex.split  # ["a", "b", "c"]
-#   "a1b2c3" "[0-9]" regex.split  # ["a", "b", "c"]
+#   "a,b,c" "," regex.split drop  # ["a", "b", "c"]
+#   "a1b2c3" "[0-9]" regex.split drop  # ["a", "b", "c"]
 #
 # Your task: Split strings using regex patterns
 # When done, delete the marker line below.
@@ -16,14 +17,14 @@
 : split-csv ( String -- List )
     # Split on comma with optional surrounding whitespace
     # "a, b,  c" -> ["a", "b", "c"]
-    # Pattern: ,\s* or \s*,\s*
+    # Pattern: \s*,\s* (drop the success Bool)
     # Your code here
     drop list-of
 ;
 
 : split-sentences ( String -- List )
     # Split on sentence-ending punctuation (. ! ?)
-    # Pattern: [.!?]+\s*
+    # Pattern: [.!?]+\s* (drop the success Bool)
     # Your code here
     drop list-of
 ;

--- a/hints/12-type-conversions/02-string-to-int.md
+++ b/hints/12-type-conversions/02-string-to-int.md
@@ -1,17 +1,31 @@
 # Hint: String to Integer
 
 The `string->int` function parses a string as an integer.
+It returns `(Int Bool)` - the value and a success flag.
 
 ## Solution
 
 ```seq
-"42" string->int 2 i.*
+"42" string->int drop 2 i.*
 ```
 
 1. `"42"` pushes the string
-2. `string->int` parses it to integer 42
-3. `2 i.*` multiplies by 2
+2. `string->int` parses it, returning `( 42 true )`
+3. `drop` removes the success Bool (we know "42" is valid)
+4. `2 i.*` multiplies by 2
 
 ## Note on Parsing
 
-If the string doesn't represent a valid integer, parsing will fail. Always ensure your input strings are valid numbers.
+If the string doesn't represent a valid integer:
+```seq
+"abc" string->int  # ( 0 false )
+```
+
+For robust code, check the Bool before using the value:
+```seq
+string->int if
+  # success - use the value
+else
+  drop 0  # failure - drop invalid value, use default
+then
+```

--- a/solutions/03-arithmetic/04-divide.seq
+++ b/solutions/03-arithmetic/04-divide.seq
@@ -1,4 +1,5 @@
 : test-divide ( -- )
     100 8 i./
+    test.assert
     12 test.assert-eq
 ;

--- a/solutions/07-conditionals/04-fizzbuzz.seq
+++ b/solutions/07-conditionals/04-fizzbuzz.seq
@@ -1,11 +1,11 @@
 : fizzbuzz ( Int -- String )
-    dup 15 i.% 0 i.= if
+    dup 15 i.% drop 0 i.= if
         drop "FizzBuzz"
     else
-        dup 3 i.% 0 i.= if
+        dup 3 i.% drop 0 i.= if
             drop "Fizz"
         else
-            dup 5 i.% 0 i.= if
+            dup 5 i.% drop 0 i.= if
                 drop "Buzz"
             else
                 int->string

--- a/solutions/08-words/05-helper-words.seq
+++ b/solutions/08-words/05-helper-words.seq
@@ -1,5 +1,5 @@
 : is-even? ( Int -- Bool )
-    2 i.mod 0 =
+    2 i.mod drop 0 i.=
 ;
 
 : test-helper-words ( -- )

--- a/solutions/11-types/02-int-ops.seq
+++ b/solutions/11-types/02-int-ops.seq
@@ -10,10 +10,12 @@
 
 : test-int-divide ( -- )
     17 5 i./
+    test.assert
     3 test.assert-eq
 ;
 
 : test-int-mod ( -- )
     17 5 i.mod
+    test.assert
     2 test.assert-eq
 ;

--- a/solutions/12-type-conversions/02-string-to-int.seq
+++ b/solutions/12-type-conversions/02-string-to-int.seq
@@ -1,4 +1,4 @@
 : test-string-to-int ( -- )
-    "42" string->int unwrap 2 i.*
+    "42" string->int drop 2 i.*
     84 test.assert-eq
 ;

--- a/solutions/26-tcp/05-echo.seq
+++ b/solutions/26-tcp/05-echo.seq
@@ -1,7 +1,7 @@
 : echo-handler ( socket -- )
-    dup tcp.read
-    over tcp.write
-    tcp.close
+    dup tcp.read drop
+    over tcp.write drop
+    tcp.close drop
 ;
 
 : test-echo ( -- )

--- a/solutions/31-regex/02-find.seq
+++ b/solutions/31-regex/02-find.seq
@@ -3,7 +3,7 @@
 ;
 
 : find-all-words ( String -- List )
-    "\\w+" regex.find-all
+    "\\w+" regex.find-all drop
 ;
 
 : test-find ( -- )

--- a/solutions/31-regex/03-replace.seq
+++ b/solutions/31-regex/03-replace.seq
@@ -1,9 +1,9 @@
 : censor-numbers ( String -- String )
-    "\\d" "X" regex.replace-all
+    "\\d" "X" regex.replace-all drop
 ;
 
 : normalize-whitespace ( String -- String )
-    "\\s+" " " regex.replace-all
+    "\\s+" " " regex.replace-all drop
 ;
 
 : test-replace ( -- )

--- a/solutions/31-regex/05-split.seq
+++ b/solutions/31-regex/05-split.seq
@@ -1,9 +1,9 @@
 : split-csv ( String -- List )
-    "\\s*,\\s*" regex.split
+    "\\s*,\\s*" regex.split drop
 ;
 
 : split-sentences ( String -- List )
-    "[.!?]+\\s*" regex.split
+    "[.!?]+\\s*" regex.split drop
 ;
 
 : test-split ( -- )


### PR DESCRIPTION
  Division/Modulo (now return (value Bool)):
  - exercises/03-arithmetic/04-divide.seq + solution
  - exercises/11-types/02-int-ops.seq + solution
  - exercises/07-conditionals/04-fizzbuzz.seq + solution
  - exercises/08-words/05-helper-words.seq + solution

  TCP operations (now return Bool):
  - exercises/26-tcp/01-listen.seq
  - exercises/26-tcp/02-accept.seq
  - exercises/26-tcp/03-read-write.seq
  - exercises/26-tcp/04-close.seq
  - exercises/26-tcp/05-echo.seq + solution

  Regex operations (now return (result Bool)):
  - exercises/31-regex/02-find.seq + solution
  - exercises/31-regex/03-replace.seq + solution
  - exercises/31-regex/05-split.seq + solution

  Result pattern changes (std:result removed):
  - exercises/12-type-conversions/02-string-to-int.seq + solution + hint
  - exercises/14-variants/03-result.seq (updated note)
  - exercises/14-variants/04-match.seq (updated unwrap reference)

  The key pattern change: operations that can fail now return (value Bool) instead of panicking or returning Result types. Users drop the Bool when they
  know it will succeed, or check it for proper error handling.