### PR TITLE
completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +580,7 @@ name = "seqlings"
 version = "3.10.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "colored",
  "ctrlc",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 colored = "2"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,33 @@ Found a bug or want to improve an exercise? PRs welcome!
 
 If you find gaps in the Seq language itself, please open issues at [patch-seq](https://github.com/navicore/patch-seq).
 
+## Shell Completions
+
+Seqlings can print a completion script for your shell. Redirect it to a file your shell picks up on startup.
+
+**zsh**
+```bash
+mkdir -p ~/.zfunc
+seqlings completions zsh > ~/.zfunc/_seqlings
+# Make sure ~/.zfunc is on your fpath. Add to ~/.zshrc if it isn't:
+#   fpath=(~/.zfunc $fpath)
+#   autoload -U compinit && compinit
+```
+
+**bash**
+```bash
+seqlings completions bash > ~/.local/share/bash-completion/completions/seqlings
+```
+
+**fish**
+```bash
+seqlings completions fish > ~/.config/fish/completions/seqlings.fish
+```
+
+**PowerShell** and **Elvish** are also supported — pass `powershell` or `elvish` to `seqlings completions`.
+
+Restart your shell after installing and `seqlings <TAB>` will complete subcommands and flags.
+
 ## Documentation
 
 Rendered docs are published to `https://navicore.github.io/seqlings/`. Build locally with `just docs` (serve) or `just build-docs` (one-shot). The site pulls content from `docs/` plus a generated copy of `README.md`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@
 mod exercise;
 mod runner;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 use colored::Colorize;
 use exercise::{Exercise, ExerciseStatus, load_exercises};
 use include_dir::{Dir, include_dir};
@@ -124,15 +125,29 @@ enum Commands {
     Verify,
     /// Skip to the next exercise
     Next,
+    /// Print a shell completion script to stdout
+    ///
+    /// Example: seqlings completions zsh > ~/.zfunc/_seqlings
+    Completions {
+        /// Target shell (bash, zsh, fish, powershell, elvish)
+        shell: Shell,
+    },
 }
 
 fn main() {
     let cli = Cli::parse();
 
-    // Handle init command before loading exercises (since exercises may not exist yet)
-    if let Some(Commands::Init { path }) = cli.command {
-        cmd_init(&path);
-        return;
+    // Handle commands that don't need an exercise tree on disk.
+    match cli.command {
+        Some(Commands::Init { ref path }) => {
+            cmd_init(path);
+            return;
+        }
+        Some(Commands::Completions { shell }) => {
+            cmd_completions(shell);
+            return;
+        }
+        _ => {}
     }
 
     // Load exercises
@@ -158,7 +173,7 @@ fn main() {
     }
 
     match cli.command {
-        Some(Commands::Init { .. }) => unreachable!(), // Handled above
+        Some(Commands::Init { .. }) | Some(Commands::Completions { .. }) => unreachable!(), // Handled above
         Some(Commands::Watch { chapter }) => {
             let filtered = filter_by_chapter(&exercises, chapter.as_deref());
             cmd_watch(&filtered);
@@ -230,6 +245,12 @@ fn filter_by_chapter(exercises: &[Exercise], chapter: Option<&str>) -> Vec<Exerc
             filtered
         }
     }
+}
+
+/// Print a shell completion script to stdout.
+fn cmd_completions(shell: Shell) {
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "seqlings", &mut std::io::stdout());
 }
 
 /// Initialize a new seqlings project directory


### PR DESCRIPTION
  What you can do now:

  # zsh
  mkdir -p ~/.zfunc
  seqlings completions zsh > ~/.zfunc/_seqlings

  # bash
  seqlings completions bash >
  ~/.local/share/bash-completion/completions/seqlings

  # fish
  seqlings completions fish > ~/.config/fish/completions/seqlings.fish

  Supported shells: bash, zsh, fish, powershell, elvish. After a shell
  restart, seqlings <TAB> will complete subcommands (watch, list, hint,
  reset, verify, next, init, completions) and their flags (e.g., --chapter).

  Files touched:
  - Cargo.toml — added clap_complete = "4"
  - Cargo.lock — regenerated by cargo build
  - src/main.rs — added Completions { shell } subcommand, cmd_completions() function, and routing in main() so it short-circuits before load_exercises() (so it works even outside a project directory)
  - README.md — added a Shell Completions section with install snippets per shell

  just ci stays green. The subcommand appears in --help and completions
  --help explains the shells supported.